### PR TITLE
🛸 use react-dom 18 hydration api

### DIFF
--- a/packages/remix-app/app/entry.client.tsx
+++ b/packages/remix-app/app/entry.client.tsx
@@ -1,10 +1,8 @@
 import { RemixBrowser } from "@remix-run/react";
-import { hydrate } from "react-dom";
+import { hydrateRoot } from "react-dom/client";
 import init from "../../rust_functions/build/browser/rust_functions";
 import wasm from "../../rust_functions/build/browser/rust_functions_bg.wasm"
 
-init(wasm).then(() => {
-    hydrate(<RemixBrowser />, document);
-})
+init(wasm).then(() => hydrateRoot(document, <RemixBrowser />))
 
 


### PR DESCRIPTION
eliminates the console error and seems to run just fine in react 18

(btw, it was a pleasure making your acquaintance at remix conf, ben—I was the guy talking about the roof geometry app)

you should consider making this a template repo!